### PR TITLE
[IDP-672] Remove FullBuildMetaData from our library versioning

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
-assembly-informational-format: "{InformationalVersion}"
+assembly-informational-format: "{NuGetVersion}"
 mode: ContinuousDelivery
 increment: Inherit
 continuous-delivery-fallback-tag: ci

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
+    <AnalysisLevel>latest-All</AnalysisLevel>
     <Description>Provides additional informational and validation attributes that can be used during model binding.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
## What are the changes
Instead of using `assembly-informational-format: '{InformationalVersion}'`, we decided to use `NuGetVersion`. The original value combines the MajorMinorPatch along with the full build metadata which yields a result similar to this: `3.22.11-beta.99+88.Branch.release/3.022.011.Sha.28c853159a46b5a87e6cc9c4f6e940c59d6bc68a`. That value is being used as the library version displayed in our telemetry library field. Instead, using NuGetVersion yields a result of MajorMinorPatch appended with a prerelease tag if relevant such as: `3.22.11-preview0099
`

## How was it validated?
We updated the GitVersion.yml of our MediaTR project to use NuGetVersion instead and installed it to send telemetry to a private honeycomb sink. On the honeycomb, we verified that the library version was indeed the appropriate field.
![image](https://github.com/gsoft-inc/wl-authentication-clientcredentialsgrant/assets/158102624/222de2fa-8f59-400c-90e1-9c4564cd4034)

Additionally, our auditing repo already uses [NuGetVersion as seen here](https://dev.azure.com/gsoft/Shared-Assets/_git/Workleap.Compliance.Auditing?path=/GitVersion.yml&version=GBmain&line=3&lineEnd=4&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents).

## References:
https://gitversion.net/docs/reference/variables